### PR TITLE
Fixed a bug in Valorant path that creates a path with two lines

### DIFF
--- a/source/Riot.cs
+++ b/source/Riot.cs
@@ -124,7 +124,7 @@ namespace Riot
                     if (File.Exists("C:\\ProgramData\\Riot Games\\Metadata\\valorant.live\\valorant.live.product_settings.yaml"))
                     {
                         string text = File.ReadAllText("C:\\ProgramData\\Riot Games\\Metadata\\valorant.live\\valorant.live.product_settings.yaml");
-                        Regex cusRegex = new Regex("product_install_full_path: .*");
+                        Regex cusRegex = new Regex("product_install_full_path: \".*\"");
                         var result = cusRegex.Match(text).Value.Replace("product_install_full_path: ", string.Empty).Replace("\"", "");
                         return result;
                     }


### PR DESCRIPTION
Hi, I had a bug that makes Valorant to be unable to start since the path was incorrect.

Before the change:
![imagen](https://github.com/user-attachments/assets/3c5af1a5-9844-4318-b83e-bcde40b13548)

After the change:
![imagen](https://github.com/user-attachments/assets/c021551b-155b-4b31-9049-8ae5fe453e12)

As you can see, after the change the result is only one line instead of two.